### PR TITLE
Remove npx from the example in --help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Commands:
   help [command]                       display help for command
 
 Examples:
-  npx fpl install hl7.fhir.us.core@current
+  fpl install hl7.fhir.us.core@current
   fpl install hl7.fhir.us.core@4.0.0 hl7.fhir.us.mcode@2.0.0 --cachePath ./myProject
 ```
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,7 @@ function getVersion(): string {
 function getHelpText(): string {
   return `
 Examples:
-  npx fpl install hl7.fhir.us.core@current
+  fpl install hl7.fhir.us.core@current
   fpl install hl7.fhir.us.core@4.0.0 hl7.fhir.us.mcode@2.0.0 --cachePath ./myProject`;
 }
 


### PR DESCRIPTION
This PR just removes `npx` from the examples provided in the `--help` text in the CLI. It doesn't really make sense to include because you need to be using FPL to get the help text, so it isn't really necessary to include. It was also wrong since `npx` will use the package name, which is `fhir-package-loader`. Instructions for using `npx` and the correct command are still included in the README.