### PR TITLE
Only load current packages from main or master branches

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -152,7 +152,9 @@ export async function mergeDependency(
     // Find matching packages and sort by date to get the most recent
     let newestPackage;
     if (qaData?.length > 0) {
-      const matchingPackages = qaData.filter(p => p['package-id'] === packageName);
+      const matchingPackages = qaData
+        .filter(p => p['package-id'] === packageName)
+        .filter(p => p.repo.match(/(master|main)\/qa\.json$/));
       newestPackage = matchingPackages.sort((p1, p2) => {
         return Date.parse(p2['date']) - Date.parse(p1['date']);
       })[0];


### PR DESCRIPTION
This PR fixes SUSHI issue [#1017](https://github.com/FHIR/sushi/issues/1017). It supports only downloading current packages from `main` or `master` branches by filtering out the `qas.json` entries that are not from those branches. This will affect SUSHI and resolve the issue once a new version of FPL is released and integrated into SUSHI (likely as part of the next major release).