### PR TITLE
Cimpl 960 fpl use new axiosget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1185,7 +1185,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -1636,7 +1635,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       },
@@ -1644,8 +1642,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2341,7 +2338,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "chalk": "^4.1.2",
     "commander": "^8.3.0",
     "fs-extra": "^10.0.0",
+    "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.21",
     "tar": "^5.0.11",
     "temp": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "Julian Carter <jacarter@mitre.org>",
     "Nick Freiter <nfreiter@mitre.org>",
     "Chris Moesel <cmoesel@mitre.org>",
-    "Mint Thompson <mathompson@mitre.org>"
+    "Mint Thompson <mathompson@mitre.org>",
+    "Guhan B. Thuran <gthuran@mitre.org>"
   ],
   "repository": {
     "type": "git",

--- a/src/load.ts
+++ b/src/load.ts
@@ -107,7 +107,6 @@ export async function mergeDependency(
   cachePath: string = path.join(os.homedir(), '.fhir', 'packages'),
   log: LogFunction = () => {}
 ): Promise<FHIRDefinitions> {
-  log('info', 'mergedependency');
   let fullPackageName = `${packageName}#${version}`;
   const loadPath = path.join(cachePath, fullPackageName, 'package');
   let loadedPackage: string;

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,7 +1,7 @@
 import { PackageLoadError, CurrentPackageLoadError } from './errors';
 import { FHIRDefinitions } from './FHIRDefinitions';
 import { LogFunction } from './utils';
-import axios from 'axios';
+import { axiosGet } from './utils/axiosUtils';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
@@ -107,6 +107,7 @@ export async function mergeDependency(
   cachePath: string = path.join(os.homedir(), '.fhir', 'packages'),
   log: LogFunction = () => {}
 ): Promise<FHIRDefinitions> {
+  log('info', 'mergedependency');
   let fullPackageName = `${packageName}#${version}`;
   const loadPath = path.join(cachePath, fullPackageName, 'package');
   let loadedPackage: string;
@@ -147,7 +148,7 @@ export async function mergeDependency(
     // Even if a local current package is loaded, we must still check that the local package date matches
     // the date on the most recent version on build.fhir.org. If the date does not match, we re-download to the cache
     const baseUrl = 'https://build.fhir.org/ig';
-    const res = await axios.get(`${baseUrl}/qas.json`);
+    const res = await axiosGet(`${baseUrl}/qas.json`);
     const qaData: { 'package-id': string; date: string; repo: string }[] = res?.data;
     // Find matching packages and sort by date to get the most recent
     let newestPackage;
@@ -163,7 +164,7 @@ export async function mergeDependency(
       const packagePath = newestPackage.repo.slice(0, -8); // remove "/qa.json" from end
       const igUrl = `${baseUrl}/${packagePath}`;
       // get the package.manifest.json for the newest version of the package on build.fhir.org
-      const manifest = await axios.get(`${igUrl}/package.manifest.json`);
+      const manifest = await axiosGet(`${igUrl}/package.manifest.json`);
       let cachedPackageJSON;
       if (fs.existsSync(path.join(loadPath, 'package.json'))) {
         cachedPackageJSON = fs.readJSONSync(path.join(loadPath, 'package.json'));
@@ -207,7 +208,7 @@ export async function mergeDependency(
   if (packageUrl) {
     const doDownload = async (url: string) => {
       log('info', `Downloading ${fullPackageName}... ${url}`);
-      const res = await axios.get(url, {
+      const res = await axiosGet(url, {
         responseType: 'arraybuffer'
       });
       if (res?.data) {

--- a/src/utils/axiosUtils.ts
+++ b/src/utils/axiosUtils.ts
@@ -1,0 +1,28 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import HttpsProxyAgent from 'https-proxy-agent';
+
+/**
+ * This function is called to better handle axios.get calls with logic that allows
+ * the use of proxies. Not needed in tests unless specifically testing with proxies.
+ * Check https://github.com/axios/axios/issues/3459#issuecomment-766171276 for more info.
+ * @param url {string} - string representation of url to get
+ * @param responseType {any} - optional parameter to change the data type needed from get
+ * (ex. arraybuffer). In default it returns JSON
+ */
+export async function axiosGet(
+  url: string,
+  options?: AxiosRequestConfig
+): Promise<AxiosResponse<any>> {
+  const httpsProxy = process.env.HTTPS_PROXY;
+  const axiosOptions = options ?? {};
+  if (httpsProxy) {
+    // https://github.com/axios/axios/issues/3459
+    axiosOptions.httpsAgent = new (HttpsProxyAgent as any)(httpsProxy);
+    axiosOptions.proxy = false;
+  }
+  if (Object.keys(axiosOptions).length > 0) {
+    return await axios.get(url, axiosOptions);
+  } else {
+    return await axios.get(url);
+  }
+}

--- a/test/utils/axiosUtils.test.ts
+++ b/test/utils/axiosUtils.test.ts
@@ -1,0 +1,37 @@
+import axios from 'axios';
+import HttpsProxyAgent from 'https-proxy-agent';
+import { axiosGet } from '../../src/utils/axiosUtils';
+
+describe('axiosUtils', () => {
+  beforeAll(() => {
+    delete process.env.HTTPS_PROXY;
+  });
+  afterEach(() => {
+    delete process.env.HTTPS_PROXY;
+  });
+  describe('#axiosGet', () => {
+    it('returns get with responseType assigned when it is used as argument', async () => {
+      const getSpy = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.resolve({}));
+      await axiosGet('packages.fhir.org/de.basisprofil.r4/1.1.0', { responseType: 'arraybuffer' });
+      expect(getSpy).toHaveBeenCalledWith('packages.fhir.org/de.basisprofil.r4/1.1.0', {
+        responseType: 'arraybuffer'
+      });
+    });
+
+    it('returns get without responseType assigned by default', async () => {
+      const getSpy = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.resolve({}));
+      await axiosGet('packages.fhir.org/de.basisprofil.r4/1.1.0');
+      expect(getSpy).toHaveBeenCalledWith('packages.fhir.org/de.basisprofil.r4/1.1.0');
+    });
+
+    it('calls get with proxy agent when https env variable is set', async () => {
+      const getSpy = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.resolve({}));
+      process.env.HTTPS_PROXY = 'https://127.0.0.1:2626';
+      await axiosGet('packages.fhir.org/de.basisprofil.r4/1.1.0');
+      expect(getSpy).toHaveBeenCalledWith('packages.fhir.org/de.basisprofil.r4/1.1.0', {
+        httpsAgent: new (HttpsProxyAgent as any)('https://127.0.0.1:2626'),
+        proxy: false
+      });
+    });
+  });
+});


### PR DESCRIPTION
Implements `axiosGet` utility into FPL. This is to handle the usage of a proxy.

To test:

- Make sure you have docker installed
- Set up a proxy server through docker: `docker run --name squid -d -p 3128:3128 datadog/squid` (if `squid` is already installed, run `docker start squid` or press the play button on docker desktop).
- The following terminal inputs all must be done in the same terminal instance for the proxy to be properly set up:
- Set up environment variable `HTTPS_PROXY` as such: `export HTTPS_PROXY=http://127.0.0.1:3128`
- Use `env|grep PROXY` to verify that you're using a proxy
- `curl google.com` just to make sure you're connected
- Delete local .fhir cache
- Run FPL with any package, example: `ts-node src/app.ts install hl7.fhir.us.core@current`
- If package downloads correctly, it is working correctly. If it displays an error regarding the package download failing, then it is breaking.
- `unset HTTPS_PROXY` will let you stop using the proxy. Again you can use `env|grep` to verify the proxy is not running anymore
- Turn off the docker container: `docker stop squid`, or press the stop button on docker desktop

Question for reviewers:
When I set my proxy up using `export https_proxy=http://127.0.0.1:3128`, `env|grep proxy` still recognized the set up proxy. However when I changed `axiosGet` to check for `process.env.https_proxy`, it was not detecting this set up proxy. Let me know if this is necessary utility to add and if time should be spent diagnosing this.