### PR TITLE
Avoid returning duplicate definitions

### DIFF
--- a/src/FHIRDefinitions.ts
+++ b/src/FHIRDefinitions.ts
@@ -1,4 +1,5 @@
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual, uniqWith, uniq } from 'lodash';
+import { DoubleMap } from './utils';
 
 /** Class representing the FHIR definitions in one or more FHIR packages */
 export class FHIRDefinitions {
@@ -18,15 +19,15 @@ export class FHIRDefinitions {
   /** Create a FHIRDefinitions */
   constructor() {
     this.package = '';
-    this.resources = new Map();
-    this.logicals = new Map();
-    this.profiles = new Map();
-    this.extensions = new Map();
-    this.types = new Map();
-    this.valueSets = new Map();
-    this.codeSystems = new Map();
-    this.implementationGuides = new Map();
-    this.packageJsons = new Map();
+    this.resources = new DoubleMap();
+    this.logicals = new DoubleMap();
+    this.profiles = new DoubleMap();
+    this.extensions = new DoubleMap();
+    this.types = new DoubleMap();
+    this.valueSets = new DoubleMap();
+    this.codeSystems = new DoubleMap();
+    this.implementationGuides = new DoubleMap();
+    this.packageJsons = new DoubleMap();
     this.childFHIRDefs = [];
     this.unsuccessfulPackageLoad = false;
   }
@@ -34,28 +35,37 @@ export class FHIRDefinitions {
   /** Get the total number of definitions */
   size(): number {
     return (
-      this.resources.size +
-      this.logicals.size +
-      this.profiles.size +
-      this.extensions.size +
-      this.types.size +
-      this.valueSets.size +
-      this.codeSystems.size +
-      this.implementationGuides.size +
-      this.childFHIRDefs.map(def => def.size()).reduce((a, b) => a + b, 0)
+      this.allResources().length +
+      this.allLogicals().length +
+      this.allProfiles().length +
+      this.allExtensions().length +
+      this.allTypes().length +
+      this.allValueSets().length +
+      this.allCodeSystems().length +
+      this.allImplementationGuides().length
     );
   }
 
   // NOTE: These all return clones of the JSON to prevent the source values from being overwritten
 
   /**
-   * Get all resources
+   * Get all resources. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of resources
    */
   allResources(fhirPackage?: string): any[] {
+    if (
+      (this.resources.size > 0 && this.childFHIRDefs.length > 0) ||
+      this.childFHIRDefs.length > 1
+    ) {
+      return uniqWith(this.collectResources(fhirPackage), isEqual);
+    }
+    return this.collectResources(fhirPackage);
+  }
+
+  protected collectResources(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allResources(fhirPackage))
+      .map(def => def.collectResources(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let resources = this.resources;
     if (fhirPackage) {
@@ -68,13 +78,23 @@ export class FHIRDefinitions {
   }
 
   /**
-   * Get all logicals
+   * Get all logicals. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of logicals
    */
   allLogicals(fhirPackage?: string): any[] {
+    if (
+      (this.logicals.size > 0 && this.childFHIRDefs.length > 0) ||
+      this.childFHIRDefs.length > 1
+    ) {
+      return uniqWith(this.collectLogicals(fhirPackage), isEqual);
+    }
+    return uniqWith(this.collectLogicals(fhirPackage), isEqual);
+  }
+
+  protected collectLogicals(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allLogicals(fhirPackage))
+      .map(def => def.collectLogicals(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let logicals = this.logicals;
     if (fhirPackage) {
@@ -87,13 +107,23 @@ export class FHIRDefinitions {
   }
 
   /**
-   * Get all profiles
+   * Get all profiles. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of profiles
    */
   allProfiles(fhirPackage?: string): any[] {
+    if (
+      (this.profiles.size > 0 && this.childFHIRDefs.length > 0) ||
+      this.childFHIRDefs.length > 1
+    ) {
+      return uniqWith(this.collectProfiles(fhirPackage), isEqual);
+    }
+    return this.collectProfiles(fhirPackage);
+  }
+
+  protected collectProfiles(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allProfiles(fhirPackage))
+      .map(def => def.collectProfiles(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let profiles = this.profiles;
     if (fhirPackage) {
@@ -106,13 +136,23 @@ export class FHIRDefinitions {
   }
 
   /**
-   * Get all extensions
+   * Get all extensions. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of extensions
    */
   allExtensions(fhirPackage?: string): any[] {
+    if (
+      (this.extensions.size > 0 && this.childFHIRDefs.length > 0) ||
+      this.childFHIRDefs.length > 1
+    ) {
+      return uniqWith(this.collectExtensions(fhirPackage), isEqual);
+    }
+    return this.collectExtensions(fhirPackage);
+  }
+
+  protected collectExtensions(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allExtensions(fhirPackage))
+      .map(def => def.collectExtensions(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let extensions = this.extensions;
     if (fhirPackage) {
@@ -125,13 +165,20 @@ export class FHIRDefinitions {
   }
 
   /**
-   * Get all types
+   * Get all types. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of types
    */
   allTypes(fhirPackage?: string): any[] {
+    if ((this.types.size > 0 && this.childFHIRDefs.length > 0) || this.childFHIRDefs.length > 1) {
+      return uniqWith(this.collectTypes(fhirPackage), isEqual);
+    }
+    return this.collectTypes(fhirPackage);
+  }
+
+  protected collectTypes(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allTypes(fhirPackage))
+      .map(def => def.collectTypes(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let types = this.types;
     if (fhirPackage) {
@@ -144,13 +191,23 @@ export class FHIRDefinitions {
   }
 
   /**
-   * Get all value sets
+   * Get all value sets. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of value sets
    */
   allValueSets(fhirPackage?: string): any[] {
+    if (
+      (this.valueSets.size > 0 && this.childFHIRDefs.length > 0) ||
+      this.childFHIRDefs.length > 1
+    ) {
+      return uniqWith(this.collectValueSets(fhirPackage), isEqual);
+    }
+    return this.collectValueSets(fhirPackage);
+  }
+
+  protected collectValueSets(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allValueSets(fhirPackage))
+      .map(def => def.collectValueSets(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let valueSets = this.valueSets;
     if (fhirPackage) {
@@ -163,13 +220,23 @@ export class FHIRDefinitions {
   }
 
   /**
-   * Get all code systems
+   * Get all code systems. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of code systems
    */
   allCodeSystems(fhirPackage?: string): any[] {
+    if (
+      (this.codeSystems.size > 0 && this.childFHIRDefs.length > 0) ||
+      this.childFHIRDefs.length > 1
+    ) {
+      return uniqWith(this.collectCodeSystems(fhirPackage), isEqual);
+    }
+    return this.collectCodeSystems(fhirPackage);
+  }
+
+  protected collectCodeSystems(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allCodeSystems(fhirPackage))
+      .map(def => def.collectCodeSystems(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let codeSystems = this.codeSystems;
     if (fhirPackage) {
@@ -182,13 +249,23 @@ export class FHIRDefinitions {
   }
 
   /**
-   * Get all implementation guides
+   * Get all implementation guides. The array will not contain duplicates.
    * @param {string} [fhirPackage] - The package (packageId#version) to search in. If not provided, searches all packages.
    * @returns array of implementation guides
    */
   allImplementationGuides(fhirPackage?: string): any[] {
+    if (
+      (this.implementationGuides.size > 0 && this.childFHIRDefs.length > 0) ||
+      this.childFHIRDefs.length > 1
+    ) {
+      return uniqWith(this.collectImplementationGuides(fhirPackage), isEqual);
+    }
+    return this.collectImplementationGuides(fhirPackage);
+  }
+
+  protected collectImplementationGuides(fhirPackage?: string): any[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allImplementationGuides(fhirPackage))
+      .map(def => def.collectImplementationGuides(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     let implementationGuides = this.implementationGuides;
     if (fhirPackage) {
@@ -206,8 +283,12 @@ export class FHIRDefinitions {
    * @returns array of packages (packageId#version) that were not successfully loaded
    */
   allUnsuccessfulPackageLoads(fhirPackage?: string): string[] {
+    return uniq(this.collectUnsuccessfulPackageLoads(fhirPackage));
+  }
+
+  protected collectUnsuccessfulPackageLoads(fhirPackage?: string): string[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allUnsuccessfulPackageLoads(fhirPackage))
+      .map(def => def.collectUnsuccessfulPackageLoads(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     if (fhirPackage) {
       if (this.package === fhirPackage && this.unsuccessfulPackageLoad) {
@@ -225,8 +306,12 @@ export class FHIRDefinitions {
    * @returns array of packages (packageId#version) that are loaded
    */
   allPackages(fhirPackage?: string): string[] {
+    return uniq(this.collectPackages(fhirPackage));
+  }
+
+  protected collectPackages(fhirPackage?: string): string[] {
     const childValues = this.childFHIRDefs
-      .map(def => def.allPackages(fhirPackage))
+      .map(def => def.collectPackages(fhirPackage))
       .reduce((a, b) => a.concat(b), []);
     if (fhirPackage) {
       if (this.package === fhirPackage && this.package !== '') {

--- a/src/utils/DoubleMap.ts
+++ b/src/utils/DoubleMap.ts
@@ -1,0 +1,87 @@
+/**
+ * The DoubleMap is a Map that contains both forward and reverse mappings between keys and values.
+ * This allows the DoubleMap to easily provide a list of unique values,
+ * because each value in the internal forwardMap will be a key in the reverseMap.
+ * The reported size of a DoubleMap is the number of unique values,
+ * which is the number of keys in the reverseMap.
+ *
+ * Note that because DoubleMap.values() returns the keys from reverseMap,
+ * it may contain fewer elements than the other functions: keys(), entries(), forEach(), and the for-of iterator.
+ */
+export class DoubleMap<K, V> implements Map<K, V> {
+  private forwardMap: Map<K, V>;
+  private reverseMap: Map<V, Set<K>>;
+
+  constructor() {
+    this.forwardMap = new Map();
+    this.reverseMap = new Map();
+  }
+
+  set(key: K, value: V): this {
+    if (this.forwardMap.get(key) === value) {
+      return this;
+    }
+    this.delete(key);
+    this.forwardMap.set(key, value);
+    if (this.reverseMap.has(value)) {
+      this.reverseMap.get(value).add(key);
+    } else {
+      this.reverseMap.set(value, new Set([key]));
+    }
+    return this;
+  }
+
+  delete(key: K): boolean {
+    if (this.forwardMap.has(key)) {
+      const currentValue = this.forwardMap.get(key);
+      const currentKeys = this.reverseMap.get(currentValue);
+      currentKeys.delete(key);
+      if (currentKeys.size === 0) {
+        this.reverseMap.delete(currentValue);
+      }
+      this.forwardMap.delete(key);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  get(key: K): V {
+    return this.forwardMap.get(key);
+  }
+
+  get size(): number {
+    return this.reverseMap.size;
+  }
+
+  clear(): void {
+    this.forwardMap.clear();
+    this.reverseMap.clear();
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void {
+    this.forwardMap.forEach(callbackfn, thisArg);
+  }
+
+  has(key: K): boolean {
+    return this.forwardMap.has(key);
+  }
+
+  [Symbol.iterator](): IterableIterator<[K, V]> {
+    return this.entries();
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.forwardMap.entries();
+  }
+
+  keys(): IterableIterator<K> {
+    return this.forwardMap.keys();
+  }
+
+  values(): IterableIterator<V> {
+    return this.reverseMap.keys();
+  }
+
+  [Symbol.toStringTag]: string;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './logger';
+export * from './DoubleMap';

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -40,170 +40,172 @@ describe('#loadFromPath()', () => {
   });
 
   it('should load base FHIR resources from FHIRDefs with no children', () => {
-    expect(defs.allResources().filter(r => r.id === 'Condition')).toHaveLength(2); // added by id/name and url
+    expect(defs.allResources().filter(r => r.id === 'Condition')).toHaveLength(1);
   });
 
   it('should load base FHIR resources from all child FHIRDefs', () => {
-    expect(defsWithChildDefs.allResources().filter(r => r.id === 'Condition')).toHaveLength(4); // added by id/name and url in both childDefs
+    expect(defsWithChildDefs.allResources().filter(r => r.id === 'Condition')).toHaveLength(1);
   });
 
   it('should load base FHIR resources only from specified package', () => {
-    expect(defs.allResources('r4-definitions').filter(r => r.id === 'Condition')).toHaveLength(2); // added by id/name and url in both childDefs
+    expect(defs.allResources('r4-definitions').filter(r => r.id === 'Condition')).toHaveLength(1);
     expect(
       defsWithChildDefs.allResources('r4-definitions').filter(r => r.id === 'Condition')
-    ).toHaveLength(2); // added by id/name and url in both childDefs
+    ).toHaveLength(1); // added in both childDefs, but identical resources are returned only once
   });
 
   it('should load base FHIR primitive types from FHIRDefs with no children', () => {
-    expect(defs.allTypes().filter(r => r.id === 'boolean')).toHaveLength(2);
+    expect(defs.allTypes().filter(r => r.id === 'boolean')).toHaveLength(1);
   });
 
   it('should load base FHIR primitive types from all child FHIRDefs', () => {
-    expect(defsWithChildDefs.allTypes().filter(r => r.id === 'boolean')).toHaveLength(4);
+    expect(defsWithChildDefs.allTypes().filter(r => r.id === 'boolean')).toHaveLength(1);
   });
 
   it('should load base FHIR primitive types only from specified package', () => {
-    expect(defs.allTypes('r4-definitions').filter(r => r.id === 'boolean')).toHaveLength(2);
+    expect(defs.allTypes('r4-definitions').filter(r => r.id === 'boolean')).toHaveLength(1);
     expect(
       defsWithChildDefs.allTypes('r4-definitions').filter(r => r.id === 'boolean')
-    ).toHaveLength(2);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR complex types from FHIRDefs with no children', () => {
-    expect(defs.allTypes().filter(r => r.id === 'Address')).toHaveLength(2);
+    expect(defs.allTypes().filter(r => r.id === 'Address')).toHaveLength(1);
   });
 
   it('should load base FHIR complex types from all child FHIRDefs', () => {
-    expect(defsWithChildDefs.allTypes().filter(r => r.id === 'Address')).toHaveLength(4);
+    expect(defsWithChildDefs.allTypes().filter(r => r.id === 'Address')).toHaveLength(1);
   });
 
   it('should load base FHIR complex types from specified package', () => {
-    expect(defs.allTypes('r4-definitions').filter(r => r.id === 'Address')).toHaveLength(2);
+    expect(defs.allTypes('r4-definitions').filter(r => r.id === 'Address')).toHaveLength(1);
     expect(
       defsWithChildDefs.allTypes('r4-definitions').filter(r => r.id === 'Address')
-    ).toHaveLength(2);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR profiles from FHIRDefs with no children', () => {
-    expect(defs.allProfiles().filter(r => r.id === 'vitalsigns')).toHaveLength(3); // added by id, name, and url
+    expect(defs.allProfiles().filter(r => r.id === 'vitalsigns')).toHaveLength(1);
   });
 
   it('should load base FHIR profiles from all child FHIRDefs', () => {
-    expect(defsWithChildDefs.allProfiles().filter(r => r.id === 'vitalsigns')).toHaveLength(6); // added by id, name, and url in all childDefs
+    expect(defsWithChildDefs.allProfiles().filter(r => r.id === 'vitalsigns')).toHaveLength(1);
   });
 
   it('should load base FHIR profiles from specified package', () => {
-    expect(defs.allProfiles('r4-definitions').filter(r => r.id === 'vitalsigns')).toHaveLength(3);
+    expect(defs.allProfiles('r4-definitions').filter(r => r.id === 'vitalsigns')).toHaveLength(1);
     expect(
       defsWithChildDefs.allProfiles('r4-definitions').filter(r => r.id === 'vitalsigns')
-    ).toHaveLength(3);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR extensions from FHIRDefs with no children', () => {
-    expect(defs.allExtensions().filter(r => r.id === 'patient-mothersMaidenName')).toHaveLength(3);
+    expect(defs.allExtensions().filter(r => r.id === 'patient-mothersMaidenName')).toHaveLength(1);
   });
 
   it('should load base FHIR extensions from all child FHIRDefs', () => {
     expect(
       defsWithChildDefs.allExtensions().filter(r => r.id === 'patient-mothersMaidenName')
-    ).toHaveLength(6);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR extensions from specified package', () => {
     expect(
       defs.allExtensions('r4-definitions').filter(r => r.id === 'patient-mothersMaidenName')
-    ).toHaveLength(3);
+    ).toHaveLength(1);
     expect(
       defsWithChildDefs
         .allExtensions('r4-definitions')
         .filter(r => r.id === 'patient-mothersMaidenName')
-    ).toHaveLength(3);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR value sets from FHIRDefs with no children', () => {
-    expect(defs.allValueSets().filter(r => r.id === 'allergyintolerance-clinical')).toHaveLength(3);
+    expect(defs.allValueSets().filter(r => r.id === 'allergyintolerance-clinical')).toHaveLength(1);
   });
 
   it('should load base FHIR value sets from all child FHIRDefs', () => {
     expect(
       defsWithChildDefs.allValueSets().filter(r => r.id === 'allergyintolerance-clinical')
-    ).toHaveLength(6);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR value sets from specified package', () => {
     expect(
       defs.allValueSets('r4-definitions').filter(r => r.id === 'allergyintolerance-clinical')
-    ).toHaveLength(3);
+    ).toHaveLength(1);
     expect(
       defsWithChildDefs
         .allValueSets('r4-definitions')
         .filter(r => r.id === 'allergyintolerance-clinical')
-    ).toHaveLength(3);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR code systems from FHIRDefs with no children', () => {
     expect(defs.allCodeSystems().filter(r => r.id === 'allergyintolerance-clinical')).toHaveLength(
-      3
+      1
     );
   });
 
   it('should load base FHIR code systems from all child FHIRDefs', () => {
     expect(
       defsWithChildDefs.allCodeSystems().filter(r => r.id === 'allergyintolerance-clinical')
-    ).toHaveLength(6);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR code systems from specified package', () => {
     expect(
       defs.allCodeSystems('r4-definitions').filter(r => r.id === 'allergyintolerance-clinical')
-    ).toHaveLength(3);
+    ).toHaveLength(1);
     expect(
       defsWithChildDefs
         .allCodeSystems('r4-definitions')
         .filter(r => r.id === 'allergyintolerance-clinical')
-    ).toHaveLength(3);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR implementation guides from FHIRDefs with no children', () => {
-    expect(defs.allImplementationGuides().filter(r => r.id === 'MyIG')).toHaveLength(2);
+    expect(defs.allImplementationGuides().filter(r => r.id === 'MyIG')).toHaveLength(1);
   });
 
-  it('should load base FHIR implementation guilds from all child FHIRDefs', () => {
+  it('should load base FHIR implementation guides from all child FHIRDefs', () => {
     expect(defsWithChildDefs.allImplementationGuides().filter(r => r.id === 'MyIG')).toHaveLength(
-      4
+      1
     );
   });
 
   it('should load base FHIR implementation guides from specified package', () => {
     expect(
       defs.allImplementationGuides('r4-definitions').filter(r => r.id === 'MyIG')
-    ).toHaveLength(2);
+    ).toHaveLength(1);
     expect(
       defsWithChildDefs.allImplementationGuides('r4-definitions').filter(r => r.id === 'MyIG')
-    ).toHaveLength(2);
+    ).toHaveLength(1);
   });
 
   it('should load base FHIR logicals from FHIRDefs with no children', () => {
-    expect(defs.allLogicals().filter(r => r.id === 'MyLM')).toHaveLength(2);
+    expect(defs.allLogicals().filter(r => r.id === 'MyLM')).toHaveLength(1);
   });
 
   it('should load base FHIR logicals from all child FHIRDefs', () => {
-    expect(defsWithChildDefs.allLogicals().filter(r => r.id === 'MyLM')).toHaveLength(4);
+    expect(defsWithChildDefs.allLogicals().filter(r => r.id === 'MyLM')).toHaveLength(1);
   });
 
   it('should load base FHIR logicals from specified package', () => {
-    expect(defs.allLogicals('r4-definitions').filter(r => r.id === 'MyLM')).toHaveLength(2);
+    expect(defs.allLogicals('r4-definitions').filter(r => r.id === 'MyLM')).toHaveLength(1);
     expect(
       defsWithChildDefs.allLogicals('r4-definitions').filter(r => r.id === 'MyLM')
-    ).toHaveLength(2);
+    ).toHaveLength(1);
   });
 
   it('should load the package.json file', () => {
     expect(defs.getPackageJson('r4-definitions')).toBeDefined();
   });
 
-  it('should count size of each child FHIRDefs in total', () => {
-    expect(defsWithChildDefs.size()).toEqual(2 * defs.size());
+  it('should count size of each unique definition from child FHIRDefs in total', () => {
+    // the two child FHIRDefs are identical,
+    // so the size of the parent is equal to the size of each child.
+    expect(defsWithChildDefs.size()).toEqual(defs.size());
   });
 
   it('should get all unsuccessfully loaded packages from FHIRDefs with no children', () => {


### PR DESCRIPTION
Completes task [CIMPL-952](https://standardhealthrecord.atlassian.net/browse/CIMPL-952).

When all definitions of a specific type are retrieved from a FHIRDefinitions object, the returned array will not contain duplicates.
The reported size of the FHIRDefinitions object will count each contained definition only once, regardless of the number of times it appears.

The DoubleMap facilitates maintaining a list of unique definitions. If child definitions exist, though, it is necessary to check the resulting list for uniqueness.