### PR TITLE
Support custom package server

### DIFF
--- a/src/errors/PackageLoadError.ts
+++ b/src/errors/PackageLoadError.ts
@@ -1,8 +1,10 @@
 export class PackageLoadError extends Error {
   specReferences = ['https://confluence.hl7.org/display/FHIR/NPM+Package+Specification'];
-  constructor(public fullPackageName: string) {
+  constructor(public fullPackageName: string, public customRegistry?: string) {
     super(
-      `The package ${fullPackageName} could not be loaded locally or from the FHIR package registry.`
+      `The package ${fullPackageName} could not be loaded locally or from the ${
+        customRegistry ? 'custom ' : ''
+      }FHIR package registry${customRegistry ? ` ${customRegistry}` : ''}.`
     );
   }
 }

--- a/src/load.ts
+++ b/src/load.ts
@@ -4,6 +4,7 @@ import { LogFunction } from './utils';
 import { axiosGet } from './utils/axiosUtils';
 import fs from 'fs-extra';
 import path from 'path';
+import process from 'process';
 import os from 'os';
 import tar from 'tar';
 import temp from 'temp';
@@ -211,7 +212,11 @@ export async function mergeDependency(
       throw new CurrentPackageLoadError(fullPackageName);
     }
   } else if (!loadedPackage) {
-    packageUrl = `https://packages.fhir.org/${packageName}/${version}`;
+    if (process.env.FPL_CUSTOM_REGISTRY) {
+      packageUrl = `${process.env.FPL_CUSTOM_REGISTRY}/${packageName}/${version}`;
+    } else {
+      packageUrl = `https://packages.fhir.org/${packageName}/${version}`;
+    }
   }
 
   // If the packageUrl is set, we must download the package from that url, and extract it to our local cache

--- a/src/utils/customRegistry.ts
+++ b/src/utils/customRegistry.ts
@@ -1,0 +1,17 @@
+import process from 'process';
+import { LogFunction } from './logger';
+
+let hasLoggedCustomRegistry = false;
+
+export function getCustomRegistry(log: LogFunction = () => {}) {
+  if (process.env.FPL_REGISTRY) {
+    if (!hasLoggedCustomRegistry) {
+      hasLoggedCustomRegistry = true;
+      log(
+        'info',
+        `Using custom registry specified by FPL_REGISTRY environment variable: ${process.env.FPL_REGISTRY}`
+      );
+    }
+    return process.env.FPL_REGISTRY;
+  }
+}

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -586,7 +586,7 @@ describe('#mergeDependency()', () => {
     removeSpy = jest.spyOn(fs, 'removeSync').mockImplementation(() => {});
     moveSpy = jest.spyOn(fs, 'moveSync').mockImplementation(() => {});
     cachePath = path.join(__dirname, 'testhelpers', 'fixtures');
-    delete process.env.FPL_CUSTOM_REGISTRY;
+    delete process.env.FPL_REGISTRY;
   });
 
   beforeEach(() => {
@@ -601,7 +601,7 @@ describe('#mergeDependency()', () => {
   });
 
   afterEach(() => {
-    delete process.env.FPL_CUSTOM_REGISTRY;
+    delete process.env.FPL_REGISTRY;
   });
 
   // Packages with numerical versions
@@ -695,9 +695,20 @@ describe('#mergeDependency()', () => {
   });
 
   it('should try to load a package from a custom registry', async () => {
-    process.env.FPL_CUSTOM_REGISTRY = 'https://custom-registry.example.org';
+    process.env.FPL_REGISTRY = 'https://custom-registry.example.org';
     await expect(mergeDependency('good-thing', '0.3.6', defs, 'foo', log)).rejects.toThrow(
-      'The package good-thing#0.3.6 could not be loaded locally or from the FHIR package registry'
+      'The package good-thing#0.3.6 could not be loaded locally or from the custom FHIR package registry https://custom-registry.example.org'
+    ); // the package is never actually added to the cache, since tar is mocked
+    expectDownloadSequence(
+      'https://custom-registry.example.org/good-thing/0.3.6',
+      path.join('foo', 'good-thing#0.3.6')
+    );
+  });
+
+  it('should try to load a package from a custom registry specified with a trailing slash', async () => {
+    process.env.FPL_REGISTRY = 'https://custom-registry.example.org/';
+    await expect(mergeDependency('good-thing', '0.3.6', defs, 'foo', log)).rejects.toThrow(
+      'The package good-thing#0.3.6 could not be loaded locally or from the custom FHIR package registry https://custom-registry.example.org/'
     ); // the package is never actually added to the cache, since tar is mocked
     expectDownloadSequence(
       'https://custom-registry.example.org/good-thing/0.3.6',


### PR DESCRIPTION
Part of task [CIMPL-1000](https://standardhealthrecord.atlassian.net/browse/CIMPL-1000).

If the FPL_CUSTOM_REGISTRY environment variable is set, use it when downloading dependencies. This is useful if you are on a corporate network where you have to use a different package registry.