### PR TITLE
Fish With Version

### DIFF
--- a/src/FHIRDefinitions.ts
+++ b/src/FHIRDefinitions.ts
@@ -396,7 +396,7 @@ export class FHIRDefinitions {
       const version = versionParts.join('|') || null;
       const def = currentFHIRDefs[map].get(base);
       if (def) {
-        if (version == null || def.version == null || version === def.version) {
+        if (version == null || version === def?.version) {
           // Only return the found definition if the version matches (if provided)
           return def;
         }

--- a/src/FHIRDefinitions.ts
+++ b/src/FHIRDefinitions.ts
@@ -392,9 +392,14 @@ export class FHIRDefinitions {
     const defsToSearch: FHIRDefinitions[] = [this];
     while (defsToSearch.length > 0) {
       const currentFHIRDefs = defsToSearch.shift();
-      const def = currentFHIRDefs[map].get(item);
+      const [base, ...versionParts] = item?.split('|') ?? ['', ''];
+      const version = versionParts.join('|') || null;
+      const def = currentFHIRDefs[map].get(base);
       if (def) {
-        return def;
+        if (version == null || def.version == null || version === def.version) {
+          // Only return the found definition if the version matches (if provided)
+          return def;
+        }
       }
       if (currentFHIRDefs.childFHIRDefs.length > 0) {
         defsToSearch.push(...currentFHIRDefs.childFHIRDefs);

--- a/test/FHIRDefinitions.test.ts
+++ b/test/FHIRDefinitions.test.ts
@@ -8,15 +8,6 @@ describe('FHIRDefinitions', () => {
   beforeAll(() => {
     defs = new FHIRDefinitions();
     loadFromPath(path.join(__dirname, 'testhelpers', 'testdefs'), 'r4-definitions', defs);
-    defs.fishForFHIR('Condition');
-    defs.fishForFHIR('eLTSSServiceModel');
-    defs.fishForFHIR('boolean');
-    defs.fishForFHIR('Address');
-    defs.fishForFHIR('vitalsigns');
-    defs.fishForFHIR('patient-mothersMaidenName');
-    defs.fishForFHIR('allergyintolerance-clinical', Type.ValueSet);
-    defs.fishForFHIR('allergyintolerance-clinical', Type.CodeSystem);
-    defs.fishForFHIR('w3c-provenance-activity-type');
   });
 
   beforeEach(() => {
@@ -126,7 +117,7 @@ describe('FHIRDefinitions', () => {
       ).toEqual(allergyStatusValueSetByID);
     });
 
-    it('should find base FHIR code sytems', () => {
+    it('should find base FHIR code systems', () => {
       // Surprise!  It turns out that the AllergyIntolerance status value set and code system
       // have the same ID!
       const allergyStatusCodeSystemByID = defs.fishForFHIR(
@@ -363,6 +354,53 @@ describe('FHIRDefinitions', () => {
       // it finds the second level child (childDefs3) Condition
       const conditionByID = defsWithChildDefs.fishForFHIR('Condition', Type.Resource);
       expect(conditionByID.version).toEqual('4.0.2');
+    });
+
+    it('should find definitions when fished by id with version', () => {
+      const vitalSignsById = defs.fishForFHIR('vitalsigns|4.0.1', Type.Profile);
+      expect(vitalSignsById).toBeDefined();
+      expect(vitalSignsById.name).toBe('observation-vitalsigns');
+      expect(vitalSignsById.url).toBe('http://hl7.org/fhir/StructureDefinition/vitalsigns');
+      expect(vitalSignsById.version).toBe('4.0.1');
+    });
+
+    it('should find definitions when fished by name with version', () => {
+      const vitalSignsByName = defs.fishForFHIR('observation-vitalsigns|4.0.1', Type.Profile);
+      expect(vitalSignsByName).toBeDefined();
+      expect(vitalSignsByName.id).toBe('vitalsigns');
+      expect(vitalSignsByName.url).toBe('http://hl7.org/fhir/StructureDefinition/vitalsigns');
+      expect(vitalSignsByName.version).toBe('4.0.1');
+    });
+
+    it('should find definitions when fished by url with version', () => {
+      const vitalSignsByUrl = defs.fishForFHIR(
+        'http://hl7.org/fhir/StructureDefinition/vitalsigns|4.0.1',
+        Type.Profile
+      );
+      expect(vitalSignsByUrl).toBeDefined();
+      expect(vitalSignsByUrl.id).toBe('vitalsigns');
+      expect(vitalSignsByUrl.name).toBe('observation-vitalsigns');
+      expect(vitalSignsByUrl.version).toBe('4.0.1');
+    });
+
+    it('should find definitions with a version with | in the version', () => {
+      const simpleProfileById = defs.fishForFHIR('SimpleProfile|1.0.0|a');
+      expect(simpleProfileById).toBeDefined();
+      expect(simpleProfileById.id).toBe('SimpleProfile');
+      expect(simpleProfileById.name).toBe('SimpleProfile');
+      expect(simpleProfileById.version).toBe('1.0.0|a');
+    });
+
+    it('should return nothing if a definition with matching version is not found', () => {
+      const vitalSignsById = defs.fishForFHIR('vitalsigns|1.0.0', Type.Profile);
+      const vitalSignsByName = defs.fishForFHIR('observation-vitalsigns|1.0.0', Type.Profile);
+      const vitalSignsByUrl = defs.fishForFHIR(
+        'http://hl7.org/fhir/StructureDefinition/vitalsigns|1.0.0',
+        Type.Profile
+      );
+      expect(vitalSignsById).toBeUndefined();
+      expect(vitalSignsByName).toBeUndefined();
+      expect(vitalSignsByUrl).toBeUndefined();
     });
   });
 });

--- a/test/FHIRDefinitions.test.ts
+++ b/test/FHIRDefinitions.test.ts
@@ -402,5 +402,10 @@ describe('FHIRDefinitions', () => {
       expect(vitalSignsByName).toBeUndefined();
       expect(vitalSignsByUrl).toBeUndefined();
     });
+
+    it('should return nothing if a definition without a version is found when fishing with a version', () => {
+      const simpleProfileById = defs.fishForFHIR('SimpleProfileNoVersion|1.0.0');
+      expect(simpleProfileById).toBeUndefined();
+    });
   });
 });

--- a/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-SimpleProfile.json
+++ b/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-SimpleProfile.json
@@ -1,0 +1,49 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "SimpleProfile",
+  "url": "http://example.org/StructureDefinition/SimpleProfile",
+  "version": "1.0.0|a",
+  "name": "SimpleProfile",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "cda",
+      "uri": "http://hl7.org/v3/cda",
+      "name": "CDA (R2)"
+    },
+    {
+      "identity": "w5",
+      "uri": "http://hl7.org/fhir/fivews",
+      "name": "FiveWs Pattern Mapping"
+    },
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "loinc",
+      "uri": "http://loinc.org",
+      "name": "LOINC code for the element"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient",
+        "path": "Patient"
+      }
+    ]
+  }
+}

--- a/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-SimpleProfileNoVersion.json
+++ b/test/testhelpers/testdefs/r4-definitions/package/StructureDefinition-SimpleProfileNoVersion.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "SimpleProfileNoVersion",
+  "url": "http://example.org/StructureDefinition/SimpleProfileNoVersion",
+  "name": "SimpleProfileNoVersion",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "cda",
+      "uri": "http://hl7.org/v3/cda",
+      "name": "CDA (R2)"
+    },
+    {
+      "identity": "w5",
+      "uri": "http://hl7.org/fhir/fivews",
+      "name": "FiveWs Pattern Mapping"
+    },
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "loinc",
+      "uri": "http://loinc.org",
+      "name": "LOINC code for the element"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient",
+        "path": "Patient"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds support to FPL for fishing for a definition with a version. If a definition is fished for with a `|version` appended to the name, id, or url, FPL will return a definition only if the version of the found definition matches the one provided.