### PR TITLE
Dependency version can be "latest"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FHIR Package Loader is a utility that downloads published FHIR packages from the FHIR package registry.
 
-## Usage
+# Usage
 
 This tool can be used directly through a command line interface (CLI) or it can be used as a dependency in another JavaScript/TypeScript project to download FHIR packages and load the contents into memory.
 
@@ -10,7 +10,7 @@ FHIR Package Loader requires [Node.js](https://nodejs.org/) to be installed on t
 
 Once Node.js is installed, use either of the following methods to use the FHIR Package Loader.
 
-### Command Line
+## Command Line
 
 To download and unzip FHIR packages through the command line, you can run the following command directly:
 
@@ -73,15 +73,13 @@ Examples:
   fpl install hl7.fhir.us.core@4.0.0 hl7.fhir.us.mcode@2.0.0 --cachePath ./myProject
 ```
 
-### API
+## API
 
-Additionally, FHIR Package Loader exposes an `fpl` function that can be used to download FHIR packages and load their definitions.
+Additionally, FHIR Package Loader exposes functions that can be used to query and download packages.
 
-#### Syntax
+### fpl(fhirPackages[, options])
 
-```javascript
-fpl(fhirPackages[, options])
-```
+The `fpl` function can be used to download FHIR packages and load their definitions.
 
 #### Parameters
 
@@ -93,7 +91,7 @@ fpl(fhirPackages[, options])
 
 - `cachePath` - A string that specifies where to look for already downloaded packages and download them to if they are not found. The default is the the local [FHIR cache](https://confluence.hl7.org/pages/viewpage.action?pageId=66928417#FHIRPackageCache-Location).
 
-- `log` - A function that is responsible logging information. It takes in two strings, a level and a message, and does not return anything.
+- `log` - A function that is responsible for logging information. It takes in two strings, a level and a message, and does not return anything.
   - For example: `log: console.log` will pass in `console.log` as the logging function and the level and message will be logged as `console.log(level, message)`
 
 #### Return Value
@@ -105,7 +103,21 @@ A `Promise` that resolves to an object with the following attributes:
 - `warnings` An array of strings containing any warnings detected during package loading.
 - `failedPackages` An array of strings containing the `package#version` of any packages that encountered an error during download or load and were not properly loaded to `defs`.
 
-#### Usage
+### getLatestVersion(packageName[, log])
+
+The `getLatestVersion` function can be used to query the latest version of a FHIR package.
+
+#### Parameters
+
+`packageName` - A string that specifies the FHIR package to query.
+
+`log` - A function that is responsible for logging information. It takes in two strings, a level and a message, and does not return anything.
+
+#### Return Value
+
+A `Promise` that resolves to a string containing the latest version of the FHIR package.
+
+### Usage
 
 To use the API, FHIR Package Loader must be installed as a dependency of your project. To add it as a dependency, navigate to your project directory and use `npm` to install the package:
 
@@ -158,9 +170,9 @@ jest.mock('fhir-package-loader', () => {
 }
 ```
 
-## For Developers
+# For Developers
 
-### Installation
+## Installation
 
 FHIR Package Loader is a [TypeScript](https://www.typescriptlang.org/) project. At a minimum, it requires [Node.js](https://nodejs.org/) to build, test, and run the CLI. Developers should install Node.js 16 (LTS), although other current LTS versions are also expected to work.
 
@@ -170,13 +182,14 @@ Once Node.js is installed, run the following command from this project's root fo
 npm install
 ```
 
-### Exposed functions
+## Exposed functions
 
 While the CLI and API should be sufficient for the majority of use cases, FHIR Package Loader exposes a few additional functions and classes that can be used within JavaScript/TypeScript projects. Below are the key exports:
 
 | Export             | Description                                                                                                                                                                                                                                |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `fpl`              | API function to download and load definitions for a provided list of packages.                                                                                                                                                             |
+| `getLatestVersion` | API function to find the latest version of a package.                                                                                                                                                                                      |
 | `loadDependencies` | Takes a list of FHIR packages, a path to a directory (optional, defaults to FHIR cache), a log function (optional) and returns FHIRDefinitions from the provided packages.                                                                 |
 | `mergeDependency`  | Takes a package name, a package version, an instance of FHIRDefinitions, a path to a directory (optional, defaults to FHIR cache), a log function (optional) and returns FHIRDefinitions with definitions added directly from the package. |
 | `loadFromPath`     | Takes a path, a package and version (format: package#version), and an instance of FHIRDefinitions and loads the definitions from the provided package at the provided path into FHIRDefinitions.                                           |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc -w",
-    "test": "jest --maxWorkers=4 --coverage",
+    "test": "jest --coverage",
     "test:watch": "npm run test -- --watchAll",
     "coverage": "opener coverage/lcov-report/index.html",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import { FHIRDefinitions } from './FHIRDefinitions';
 import { ErrorsAndWarnings, LogFunction, wrapLogger } from './utils';
 import { loadDependencies } from './load';
+export { lookUpLatestVersion as getLatestVersion } from './load';
 
 export async function fpl(
   fhirPackages: string | string[],

--- a/src/errors/LatestVersionUnavailableError.ts
+++ b/src/errors/LatestVersionUnavailableError.ts
@@ -1,0 +1,9 @@
+export class LatestVersionUnavailableError extends Error {
+  constructor(public packageName: string, public customRegistry?: string) {
+    super(
+      `Latest version of package ${packageName} could not be determined from the ${
+        customRegistry ? 'custom ' : ''
+      }FHIR package registry${customRegistry ? ` ${customRegistry}` : ''}`
+    );
+  }
+}

--- a/src/load.ts
+++ b/src/load.ts
@@ -111,7 +111,7 @@ export async function mergeDependency(
   log: LogFunction = () => {}
 ): Promise<FHIRDefinitions> {
   if (version === 'latest') {
-    version = await exports.getLatestVersion(packageName, log);
+    version = await exports.lookUpLatestVersion(packageName, log);
   }
   let fullPackageName = `${packageName}#${version}`;
   const loadPath = path.join(cachePath, fullPackageName, 'package');
@@ -357,7 +357,7 @@ export function loadFromPath(
   }
 }
 
-export async function getLatestVersion(
+export async function lookUpLatestVersion(
   packageName: string,
   log: LogFunction = () => {}
 ): Promise<string> {

--- a/src/load.ts
+++ b/src/load.ts
@@ -8,6 +8,8 @@ import os from 'os';
 import tar from 'tar';
 import temp from 'temp';
 import { getCustomRegistry } from './utils/customRegistry';
+import { AxiosResponse } from 'axios';
+import { LatestVersionUnavailableError } from './errors/LatestVersionUnavailableError';
 
 /**
  * Loads multiple dependencies from a directory (the user FHIR cache or a specified directory) or from online
@@ -108,6 +110,9 @@ export async function mergeDependency(
   cachePath: string = path.join(os.homedir(), '.fhir', 'packages'),
   log: LogFunction = () => {}
 ): Promise<FHIRDefinitions> {
+  if (version === 'latest') {
+    version = await exports.getLatestVersion(packageName, log);
+  }
   let fullPackageName = `${packageName}#${version}`;
   const loadPath = path.join(cachePath, fullPackageName, 'package');
   let loadedPackage: string;
@@ -349,6 +354,38 @@ export function loadFromPath(
   // the package has already been loaded, so just return the targetPackage string.
   if (FHIRDefs.getPackageJson(targetPackage)) {
     return targetPackage;
+  }
+}
+
+export async function getLatestVersion(
+  packageName: string,
+  log: LogFunction = () => {}
+): Promise<string> {
+  const customRegistry = getCustomRegistry(log);
+  let res: AxiosResponse;
+  if (customRegistry) {
+    res = await axiosGet(`${customRegistry.replace(/\/$/, '')}/${packageName}`, {
+      responseType: 'json'
+    });
+  } else {
+    try {
+      res = await axiosGet(`https://packages.fhir.org/${packageName}`, {
+        responseType: 'json'
+      });
+    } catch (e) {
+      // Fallback to trying packages2.fhir.org
+      res = await axiosGet(`https://packages2.fhir.org/packages/${packageName}`, {
+        responseType: 'json'
+      }).catch(() => {
+        // If the fallback failed too, just throw the original error
+        throw e;
+      });
+    }
+  }
+  if (res?.data?.['dist-tags']?.latest?.length) {
+    return res.data['dist-tags'].latest;
+  } else {
+    throw new LatestVersionUnavailableError(packageName, customRegistry);
   }
 }
 

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -11,11 +11,53 @@ import {
   loadFromPath,
   mergeDependency,
   loadDependencies,
-  loadDependency
+  loadDependency,
+  getLatestVersion
 } from '../src/load';
 import { FHIRDefinitions, Type } from '../src/FHIRDefinitions';
 import { PackageLoadError } from '../src/errors';
 import { loggerSpy } from './testhelpers';
+import { LatestVersionUnavailableError } from '../src/errors/LatestVersionUnavailableError';
+
+// Represents a typical response from packages.fhir.org
+const TERM_PKG_RESPONSE = {
+  _id: 'hl7.terminology.r4',
+  name: 'hl7.terminology.r4',
+  'dist-tags': { latest: '1.2.3-test' },
+  versions: {
+    '1.2.3-test': {
+      name: 'hl7.terminology.r4',
+      version: '1.2.3-test',
+      description: 'None.',
+      dist: {
+        shasum: '1a1467bce19aace45771e0a51ef2ad9c3fe74983',
+        tarball: 'https://packages.simplifier.net/hl7.terminology.r4/1.2.3-test'
+      },
+      fhirVersion: 'R4',
+      url: 'https://packages.simplifier.net/hl7.terminology.r4/1.2.3-test'
+    }
+  }
+};
+
+// Represents a typical response from packages2.fhir.org (note: not on packages.fhir.org)
+const EXT_PKG_RESPONSE = {
+  _id: 'hl7.fhir.uv.extensions',
+  name: 'hl7.fhir.uv.extensions',
+  'dist-tags': { latest: '4.5.6-test' },
+  versions: {
+    '4.5.6-test': {
+      name: 'hl7.fhir.uv.extensions',
+      date: '2023-03-26T08:46:31-00:00',
+      version: '1.0.0',
+      fhirVersion: '??',
+      kind: '??',
+      count: '18',
+      canonical: 'http://hl7.org/fhir/extensions',
+      description: 'None',
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/4.5.6-test'
+    }
+  }
+};
 
 describe('#loadFromPath()', () => {
   let defsWithChildDefs: FHIRDefinitions;
@@ -917,6 +959,17 @@ describe('#mergeDependency()', () => {
     expect(removeSpy.mock.calls[0][0]).toBe(path.join(cachePath, 'sushi-test-old#current'));
   });
 
+  it('should load the latest version when the given version is "latest"', async () => {
+    jest.spyOn(loadModule, 'getLatestVersion').mockResolvedValueOnce('0.2.0');
+    await expect(mergeDependency('sushi-test', 'latest', defs, 'foo', log)).rejects.toThrow(
+      'The package sushi-test#0.2.0 could not be loaded locally or from the FHIR package registry'
+    ); // the package is never actually added to the cache, since tar is mocked
+    expectDownloadSequence(
+      'https://packages.fhir.org/sushi-test/0.2.0',
+      path.join('foo', 'sushi-test#0.2.0')
+    );
+  });
+
   it('should throw CurrentPackageLoadError when a current package is not listed', async () => {
     await expect(mergeDependency('hl7.fhir.us.core', 'current', defs, 'foo', log)).rejects.toThrow(
       'The package hl7.fhir.us.core#current is not available on https://build.fhir.org/ig/qas.json, so no current version can be loaded'
@@ -972,5 +1025,62 @@ describe('#cleanCachedPackage', () => {
     const packagePath = path.join(cachePath, 'sushi-test#current');
     cleanCachedPackage(packagePath);
     expect(renameSpy.mock.calls.length).toBe(0);
+  });
+});
+
+describe('#getLatestVersion', () => {
+  let axiosSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    axiosSpy = jest.spyOn(axios, 'get').mockImplementation((uri: string): any => {
+      if (
+        uri === 'https://custom-registry.example.org/hl7.terminology.r4' ||
+        uri === 'https://packages.fhir.org/hl7.terminology.r4'
+      ) {
+        return { data: TERM_PKG_RESPONSE };
+      } else if (uri === 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions') {
+        return { data: EXT_PKG_RESPONSE };
+      } else if (uri === 'https://packages.fhir.org/hl7.no.latest') {
+        return {
+          data: {
+            name: 'hl7.no.latest',
+            'dist-tags': {
+              v1: '1.5.1',
+              v2: '2.1.1'
+            }
+          }
+        };
+      } else {
+        throw new Error('Not found');
+      }
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.FPL_REGISTRY;
+  });
+
+  afterAll(() => {
+    axiosSpy.mockRestore();
+  });
+
+  it('should get the latest version for a package on the packages server', async () => {
+    const latest = await getLatestVersion('hl7.terminology.r4');
+    expect(latest).toBe('1.2.3-test');
+  });
+
+  it('should get the latest version for a package on the packages2 server', async () => {
+    const latest = await getLatestVersion('hl7.fhir.uv.extensions');
+    expect(latest).toBe('4.5.6-test');
+  });
+
+  it('should get the latest version for a package on a custom server', async () => {
+    process.env.FPL_REGISTRY = 'https://custom-registry.example.org/';
+    const latest = await getLatestVersion('hl7.terminology.r4');
+    expect(latest).toBe('1.2.3-test');
+  });
+
+  it('should throw LatestVersionUnavailableError when the package exists, but has no latest tag', async () => {
+    await expect(getLatestVersion('hl7.no.latest')).rejects.toThrow(LatestVersionUnavailableError);
   });
 });

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -1080,6 +1080,12 @@ describe('#lookUpLatestVersion', () => {
     expect(latest).toBe('1.2.3-test');
   });
 
+  it('should throw LatestVersionUnavailableError when the request to get package information fails', async () => {
+    await expect(lookUpLatestVersion('hl7.bogus.package')).rejects.toThrow(
+      LatestVersionUnavailableError
+    );
+  });
+
   it('should throw LatestVersionUnavailableError when the package exists, but has no latest tag', async () => {
     await expect(lookUpLatestVersion('hl7.no.latest')).rejects.toThrow(
       LatestVersionUnavailableError

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -12,7 +12,7 @@ import {
   mergeDependency,
   loadDependencies,
   loadDependency,
-  getLatestVersion
+  lookUpLatestVersion
 } from '../src/load';
 import { FHIRDefinitions, Type } from '../src/FHIRDefinitions';
 import { PackageLoadError } from '../src/errors';
@@ -960,7 +960,7 @@ describe('#mergeDependency()', () => {
   });
 
   it('should load the latest version when the given version is "latest"', async () => {
-    jest.spyOn(loadModule, 'getLatestVersion').mockResolvedValueOnce('0.2.0');
+    jest.spyOn(loadModule, 'lookUpLatestVersion').mockResolvedValueOnce('0.2.0');
     await expect(mergeDependency('sushi-test', 'latest', defs, 'foo', log)).rejects.toThrow(
       'The package sushi-test#0.2.0 could not be loaded locally or from the FHIR package registry'
     ); // the package is never actually added to the cache, since tar is mocked
@@ -1028,7 +1028,7 @@ describe('#cleanCachedPackage', () => {
   });
 });
 
-describe('#getLatestVersion', () => {
+describe('#lookUpLatestVersion', () => {
   let axiosSpy: jest.SpyInstance;
 
   beforeAll(() => {
@@ -1065,22 +1065,24 @@ describe('#getLatestVersion', () => {
   });
 
   it('should get the latest version for a package on the packages server', async () => {
-    const latest = await getLatestVersion('hl7.terminology.r4');
+    const latest = await lookUpLatestVersion('hl7.terminology.r4');
     expect(latest).toBe('1.2.3-test');
   });
 
   it('should get the latest version for a package on the packages2 server', async () => {
-    const latest = await getLatestVersion('hl7.fhir.uv.extensions');
+    const latest = await lookUpLatestVersion('hl7.fhir.uv.extensions');
     expect(latest).toBe('4.5.6-test');
   });
 
   it('should get the latest version for a package on a custom server', async () => {
     process.env.FPL_REGISTRY = 'https://custom-registry.example.org/';
-    const latest = await getLatestVersion('hl7.terminology.r4');
+    const latest = await lookUpLatestVersion('hl7.terminology.r4');
     expect(latest).toBe('1.2.3-test');
   });
 
   it('should throw LatestVersionUnavailableError when the package exists, but has no latest tag', async () => {
-    await expect(getLatestVersion('hl7.no.latest')).rejects.toThrow(LatestVersionUnavailableError);
+    await expect(lookUpLatestVersion('hl7.no.latest')).rejects.toThrow(
+      LatestVersionUnavailableError
+    );
   });
 });


### PR DESCRIPTION
Completes task [CIMPL-1125](https://standardhealthrecord.atlassian.net/browse/CIMPL-1125).

When the version is "latest", try to get the latest version. Then, use that version when loading the package. If the latest version is unavailable, an error is thrown. The version will be checked against a custom package registry if one has been specified.

To try this out with SUSHI, you can remove the part of SUSHI's `loadAutomaticDependencies` function that tries to handle the "latest" version, and let FPL handle it. You'll need `npm pack` FPL into a tar, then update your SUSHI dependencies to use your local FPL tar. All the output should be the same, since this implementation is nearly identical to the way SUSHI tries to handle "latest" versions.