### PR TITLE
Support wildcard patch releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3288,9 +3288,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4326,9 +4326,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4791,6 +4791,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4850,6 +4856,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -5336,23 +5348,24 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
@@ -5563,6 +5576,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5721,9 +5744,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5896,9 +5919,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -5935,9 +5958,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -8346,9 +8369,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -9167,9 +9190,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -9519,6 +9542,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9551,6 +9580,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve": {
@@ -9902,20 +9937,21 @@
       }
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "dependencies": {
         "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
           "dev": true
         }
       }
@@ -10042,6 +10078,16 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -10176,9 +10222,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "fs-extra": "^10.0.0",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.21",
+        "semver": "^7.5.4",
         "tar": "^5.0.11",
         "temp": "^0.9.1",
         "winston": "^3.3.3"
@@ -28,6 +29,7 @@
         "@types/lodash": "^4.14.177",
         "@types/node": "^14.17.27",
         "@types/opener": "^1.4.0",
+        "@types/semver": "^7.5.0",
         "@types/tar": "^4.0.3",
         "@types/temp": "^0.8.34",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
@@ -1276,6 +1278,12 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -4295,7 +4303,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4990,10 +4997,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6840,6 +6846,12 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -9141,7 +9153,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -9631,10 +9642,9 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/lodash": "^4.14.177",
     "@types/node": "^14.17.27",
     "@types/opener": "^1.4.0",
+    "@types/semver": "^7.5.0",
     "@types/tar": "^4.0.3",
     "@types/temp": "^0.8.34",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
@@ -63,6 +64,7 @@
     "fs-extra": "^10.0.0",
     "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.21",
+    "semver": "^7.5.4",
     "tar": "^5.0.11",
     "temp": "^0.9.1",
     "winston": "^3.3.3"

--- a/src/errors/IncorrectWildcardVersionFormatError.ts
+++ b/src/errors/IncorrectWildcardVersionFormatError.ts
@@ -1,0 +1,7 @@
+export class IncorrectWildcardVersionFormatError extends Error {
+  constructor(public packageName: string, version: string) {
+    super(
+      `Incorrect version format for package ${packageName}: ${version}. Wildcard should only be used to specify patch versions.`
+    );
+  }
+}

--- a/src/errors/LatestVersionUnavailableError.ts
+++ b/src/errors/LatestVersionUnavailableError.ts
@@ -2,11 +2,11 @@ export class LatestVersionUnavailableError extends Error {
   constructor(
     public packageName: string,
     public customRegistry?: string,
-    public isPatch?: boolean
+    public isPatchWildCard?: boolean
   ) {
     super(
       `Latest ${
-        isPatch ? 'patch ' : ''
+        isPatchWildCard ? 'patch ' : ''
       }version of package ${packageName} could not be determined from the ${
         customRegistry ? 'custom ' : ''
       }FHIR package registry${customRegistry ? ` ${customRegistry}` : ''}`

--- a/src/errors/LatestVersionUnavailableError.ts
+++ b/src/errors/LatestVersionUnavailableError.ts
@@ -1,7 +1,13 @@
 export class LatestVersionUnavailableError extends Error {
-  constructor(public packageName: string, public customRegistry?: string) {
+  constructor(
+    public packageName: string,
+    public customRegistry?: string,
+    public isPatch?: boolean
+  ) {
     super(
-      `Latest version of package ${packageName} could not be determined from the ${
+      `Latest ${
+        isPatch ? 'patch ' : ''
+      }version of package ${packageName} could not be determined from the ${
         customRegistry ? 'custom ' : ''
       }FHIR package registry${customRegistry ? ` ${customRegistry}` : ''}`
     );

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,2 +1,4 @@
 export * from './CurrentPackageLoadError';
+export * from './IncorrectWildcardVersionFormatError';
+export * from './LatestVersionUnavailableError';
 export * from './PackageLoadError';

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -37,38 +37,38 @@ const TERM_PKG_RESPONSE = {
       fhirVersion: 'R4',
       url: 'https://packages.simplifier.net/hl7.terminology.r4/1.2.3-test'
     },
-    '2.0.0': {
+    '1.1.0': {
       name: 'hl7.terminology.r4',
-      version: '2.0.0',
+      version: '1.1.0',
       description: 'None.',
       dist: {
         shasum: '1a1467bce19aace45771e0a51ef2ad9c3fe749820',
-        tarball: 'https://packages.simplifier.net/hl7.terminology.r4/2.0.0'
+        tarball: 'https://packages.simplifier.net/hl7.terminology.r4/1.1.0'
       },
       fhirVersion: 'R4',
-      url: 'https://packages.simplifier.net/hl7.terminology.r4/2.0.0'
+      url: 'https://packages.simplifier.net/hl7.terminology.r4/1.1.0'
     },
-    '2.0.2': {
+    '1.1.2': {
       name: 'hl7.terminology.r4',
-      version: '2.0.2',
+      version: '1.1.2',
       description: 'None.',
       dist: {
         shasum: '1a1467bce19aace45771e0a51ef2ad9c3fe749822',
-        tarball: 'https://packages.simplifier.net/hl7.terminology.r4/2.0.2'
+        tarball: 'https://packages.simplifier.net/hl7.terminology.r4/1.1.2'
       },
       fhirVersion: 'R4',
-      url: 'https://packages.simplifier.net/hl7.terminology.r4/2.0.2'
+      url: 'https://packages.simplifier.net/hl7.terminology.r4/1.1.2'
     },
-    '2.0.1': {
+    '1.1.1': {
       name: 'hl7.terminology.r4',
-      version: '2.0.1',
+      version: '1.1.1',
       description: 'None.',
       dist: {
         shasum: '1a1467bce19aace45771e0a51ef2ad9c3fe749821',
-        tarball: 'https://packages.simplifier.net/hl7.terminology.r4/2.0.1'
+        tarball: 'https://packages.simplifier.net/hl7.terminology.r4/1.1.1'
       },
       fhirVersion: 'R4',
-      url: 'https://packages.simplifier.net/hl7.terminology.r4/2.0.1'
+      url: 'https://packages.simplifier.net/hl7.terminology.r4/1.1.1'
     }
   }
 };
@@ -90,38 +90,38 @@ const EXT_PKG_RESPONSE = {
       description: 'None',
       url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/4.5.6-test'
     },
-    '2.0.0': {
+    '1.1.0': {
       name: 'hl7.fhir.uv.extensions',
       date: '2023-03-26T08:46:31-00:00',
-      version: '2.0.0',
+      version: '1.1.0',
       fhirVersion: '??',
       kind: '??',
       count: '18',
       canonical: 'http://hl7.org/fhir/extensions',
       description: 'None',
-      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/2.0.0'
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/1.1.0'
     },
-    '2.0.2': {
+    '1.1.2': {
       name: 'hl7.fhir.uv.extensions',
       date: '2023-03-26T08:46:31-00:00',
-      version: '2.0.2',
+      version: '1.1.2',
       fhirVersion: '??',
       kind: '??',
       count: '18',
       canonical: 'http://hl7.org/fhir/extensions',
       description: 'None',
-      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/2.0.2'
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/1.1.2'
     },
-    '2.0.1': {
+    '1.1.1': {
       name: 'hl7.fhir.uv.extensions',
       date: '2023-03-26T08:46:31-00:00',
-      version: '2.0.1',
+      version: '1.1.1',
       fhirVersion: '??',
       kind: '??',
       count: '18',
       canonical: 'http://hl7.org/fhir/extensions',
       description: 'None',
-      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/2.0.1'
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/1.1.1'
     }
   }
 };
@@ -1244,19 +1244,19 @@ describe('#lookUpLatestPatchVersion', () => {
   });
 
   it('should get the latest patch version for a package on the packages server', async () => {
-    const latestPatch = await lookUpLatestPatchVersion('hl7.terminology.r4', '2.0.x');
-    expect(latestPatch).toBe('2.0.2');
+    const latestPatch = await lookUpLatestPatchVersion('hl7.terminology.r4', '1.1.x');
+    expect(latestPatch).toBe('1.1.2');
   });
 
   it('should get the latest patch version for a package on the packages2 server', async () => {
-    const latestPatch = await lookUpLatestPatchVersion('hl7.fhir.uv.extensions', '2.0.x');
-    expect(latestPatch).toBe('2.0.2');
+    const latestPatch = await lookUpLatestPatchVersion('hl7.fhir.uv.extensions', '1.1.x');
+    expect(latestPatch).toBe('1.1.2');
   });
 
   it('should get the latest patch version for a package on a custom server', async () => {
     process.env.FPL_REGISTRY = 'https://custom-registry.example.org/';
-    const latestPatch = await lookUpLatestPatchVersion('hl7.terminology.r4', '2.0.x');
-    expect(latestPatch).toBe('2.0.2');
+    const latestPatch = await lookUpLatestPatchVersion('hl7.terminology.r4', '1.1.x');
+    expect(latestPatch).toBe('1.1.2');
   });
 
   it('should get the latest patch version ignoring any versions with qualifiers after the version (-snapshot1)', async () => {

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -90,38 +90,38 @@ const EXT_PKG_RESPONSE = {
       description: 'None',
       url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/4.5.6-test'
     },
-    '1.1.0': {
+    '2.0.0': {
       name: 'hl7.fhir.uv.extensions',
       date: '2023-03-26T08:46:31-00:00',
-      version: '1.1.0',
+      version: '2.0.0',
       fhirVersion: '??',
       kind: '??',
       count: '18',
       canonical: 'http://hl7.org/fhir/extensions',
       description: 'None',
-      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/1.1.0'
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/2.0.0'
     },
-    '1.1.2': {
+    '2.0.2': {
       name: 'hl7.fhir.uv.extensions',
       date: '2023-03-26T08:46:31-00:00',
-      version: '1.1.2',
+      version: '2.0.2',
       fhirVersion: '??',
       kind: '??',
       count: '18',
       canonical: 'http://hl7.org/fhir/extensions',
       description: 'None',
-      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/1.1.2'
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/2.0.2'
     },
-    '1.1.1': {
+    '2.0.1': {
       name: 'hl7.fhir.uv.extensions',
       date: '2023-03-26T08:46:31-00:00',
-      version: '1.1.1',
+      version: '2.0.1',
       fhirVersion: '??',
       kind: '??',
       count: '18',
       canonical: 'http://hl7.org/fhir/extensions',
       description: 'None',
-      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/1.1.1'
+      url: 'https://packages2.fhir.org/packages/hl7.fhir.uv.extensions/2.0.1'
     }
   }
 };
@@ -1249,8 +1249,8 @@ describe('#lookUpLatestPatchVersion', () => {
   });
 
   it('should get the latest patch version for a package on the packages2 server', async () => {
-    const latestPatch = await lookUpLatestPatchVersion('hl7.fhir.uv.extensions', '1.1.x');
-    expect(latestPatch).toBe('1.1.2');
+    const latestPatch = await lookUpLatestPatchVersion('hl7.fhir.uv.extensions', '2.0.x');
+    expect(latestPatch).toBe('2.0.2');
   });
 
   it('should get the latest patch version for a package on a custom server', async () => {


### PR DESCRIPTION
This PR adds support for using a wildcard to download the latest patch release of a package. A user can specify a version like `3.0.x`, and FPL will now find the latest patch release of `3.0`.

I think the approach I took to finding and determining the latest patch seems reasonable, but let me know if I missed anything. I also reused the `LatestVersionUnavailableError`, adding in a flag for if it was a patch version, but if anyone thinks it would be cleaner just to separate the errors, I'm happy to. I also realized I didn't include the word `"wildcard"` in the function name, so if anyone thinks that would be helpful for future-us, I'm happy to adjust it.