### PR TITLE
Enforce an order for types when fishing

### DIFF
--- a/src/FHIRDefinitions.ts
+++ b/src/FHIRDefinitions.ts
@@ -418,15 +418,9 @@ export class FHIRDefinitions {
   fishForFHIR(item: string, ...types: Type[]): any | undefined {
     // No types passed in means to search ALL supported types
     if (types.length === 0) {
-      types = [
-        Type.Resource,
-        Type.Logical,
-        Type.Type,
-        Type.Profile,
-        Type.Extension,
-        Type.ValueSet,
-        Type.CodeSystem
-      ];
+      types = FISHING_ORDER;
+    } else {
+      types.sort((a, b) => FISHING_ORDER.indexOf(a) - FISHING_ORDER.indexOf(b));
     }
 
     for (const type of types) {
@@ -493,6 +487,16 @@ export enum Type {
   Type = 'Type', // NOTE: only defined in FHIR defs, not FSHTanks
   Logical = 'Logical'
 }
+
+export const FISHING_ORDER = [
+  Type.Resource,
+  Type.Logical,
+  Type.Type,
+  Type.Profile,
+  Type.Extension,
+  Type.ValueSet,
+  Type.CodeSystem
+];
 
 // Type to represent the names of the FHIRDefinition maps of definitions
 type maps =

--- a/test/FHIRDefinitions.test.ts
+++ b/test/FHIRDefinitions.test.ts
@@ -141,8 +141,9 @@ describe('FHIRDefinitions', () => {
       ).toEqual(allergyStatusCodeSystemByID);
     });
 
-    it('should find definitions by the type order supplied', () => {
+    it('should find definitions by the enforced type order', () => {
       // NOTE: There are two things with id allergyintolerance-clinical (the ValueSet and CodeSystem)
+      // When doing a non-type-specific search, we favor the ValueSet
       const allergyStatusValueSetByID = defs.fishForFHIR(
         'allergyintolerance-clinical',
         Type.ValueSet,
@@ -155,7 +156,7 @@ describe('FHIRDefinitions', () => {
         Type.CodeSystem,
         Type.ValueSet
       );
-      expect(allergyStatusCodeSystemByID.resourceType).toBe('CodeSystem');
+      expect(allergyStatusCodeSystemByID.resourceType).toBe('ValueSet');
     });
 
     it('should not find the definition when the type is not requested', () => {


### PR DESCRIPTION
Completes task [CIMPL-1184](https://standardhealthrecord.atlassian.net/browse/CIMPL-1184).

FISHING_ORDER defines the order in which definitions will be checked when fishing. If a different order is desired, fish for types one at a time.

Given that there was an existing test that specifically checked for the opposite behavior, this probably qualifies as a breaking change. We should keep that in mind when releasing this feature.