### PR TITLE
Bump version to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhir-package-loader",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fhir-package-loader",
-      "version": "0.7.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-package-loader",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "JavaScript package for downloading and accessing FHIR definitions",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
We've been using FHIR Package Loader in SUSHI and GoFSH for a while now -- so we should bump it to 1.0.0 since we're using it in production tools.