### PR TITLE
Avoid using Dirent.path and Dirent.parentPath properties

### DIFF
--- a/src/cache/DiskBasedPackageCache.ts
+++ b/src/cache/DiskBasedPackageCache.ts
@@ -65,7 +65,7 @@ export class DiskBasedPackageCache implements PackageCache {
     return fs
       .readdirSync(contentPath, { withFileTypes: true })
       .filter(entry => entry.isFile() && /^[^.].*\.json$/i.test(entry.name))
-      .map(entry => path.resolve(entry.path, entry.name))
+      .map(entry => path.resolve(contentPath, entry.name))
       .sort();
   }
 

--- a/src/virtual/DiskBasedVirtualPackage.ts
+++ b/src/virtual/DiskBasedVirtualPackage.ts
@@ -138,11 +138,9 @@ function getFilePaths(paths: string[], recursive: boolean): string[] {
     } else if (stat.isDirectory()) {
       fs.readdirSync(p, { withFileTypes: true }).forEach(entry => {
         if (entry.isFile()) {
-          filePaths.add(path.resolve(entry.parentPath, entry.name));
+          filePaths.add(path.resolve(p, entry.name));
         } else if (recursive && entry.isDirectory()) {
-          getFilePaths([path.resolve(entry.parentPath, entry.name)], recursive).forEach(fp =>
-            filePaths.add(fp)
-          );
+          getFilePaths([path.resolve(p, entry.name)], recursive).forEach(fp => filePaths.add(fp));
         }
       });
     }


### PR DESCRIPTION
**Description:** `Dirent.path` was added in Node 18.17.0 and then deprecated in Node 18.20.0. `Dirent.parentPath` was added in Node 18.20.0. In order to keep compatibility with versions of Node before 18.17.0, don't use `Dirent.path` or `Dirent.parentPath`.

Using `Dirent.parentPath` resulted in errors when SUSHI was run on earlier versions of Node 18.x. See: https://chat.fhir.org/#narrow/channel/215610-shorthand/topic/Issue.20w.2F.20newest.20SUSHI/near/490266928

**Testing Instructions:** Run `npm test` on the _main_ branch using a Node 18 version < Node 18.17 (e.g, Node 18.16.0). You will get errors like: _TypeError: The "path" argument must be of type string. Received undefined_. Now run this PR branch using the same version of Node (e.g., Node 18.16.0). The tests should all pass.