### PR TITLE
Downgrade download error to warning if package can be loaded from cache

### DIFF
--- a/src/loader/BasePackageLoader.ts
+++ b/src/loader/BasePackageLoader.ts
@@ -123,7 +123,7 @@ export class BasePackageLoader implements PackageLoader {
     if (downloadErrorMessage) {
       // Loading succeeded despite a download error. This might happen if a current build is stale,
       // but the download fails, in which case the stale build will be loaded instead.
-      this.log('error', `${downloadErrorMessage}. Using most recent cached package instead.`);
+      this.log('warn', `${downloadErrorMessage}. Using most recent cached package instead.`);
     }
     this.log('info', `Loaded ${stats.name}#${stats.version} with ${stats.resourceCount} resources`);
     return LoadStatus.LOADED;

--- a/test/loader/BasePackageLoader.test.ts
+++ b/test/loader/BasePackageLoader.test.ts
@@ -524,7 +524,7 @@ describe('BasePackageLoader', () => {
       expect(result).toBe(LoadStatus.LOADED);
     });
 
-    it('should log an error but load cached version if it cannot download current package when current version in cache out of date', async () => {
+    it('should log a warning but load cached version if it cannot download current package when current version in cache out of date', async () => {
       const pkg = setupLoadPackage(
         'some.ig',
         'current',
@@ -562,7 +562,7 @@ describe('BasePackageLoader', () => {
       expect(loggerSpy.getMessageAtIndex(-2, 'info')).toBe(
         'Cached package some.ig#current is out of date and will be replaced by the most recent current build.'
       );
-      expect(loggerSpy.getLastMessage('error')).toBe(
+      expect(loggerSpy.getLastMessage('warn')).toBe(
         'Failed to download most recent some.ig#current from current builds. Using most recent cached package instead.'
       );
       expect(loggerSpy.getLastMessage('info')).toBe('Loaded some.ig#current with 4 resources');


### PR DESCRIPTION
**Description:** In the case of #current packages, FPL always attempts to lookup and download the latest build (if stale) -- even if there is a cached copy in the FHIR cache. Previously, if this lookup/download failed, we logged an error; now, we log a warning. This change was discussed on Zulip here: https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/Issue.20using.20version-specific.20packages/near/513733847

**Testing Instructions:** Unit tests demonstrate change. Manual testing requires some trickery:
* Install latest version of FPL: `npm install -g fhir-package-loader`
* Use FPL to install a working #current version, like US Core: `fpl install hl7.fhir.us.core#current`
* Rename the package in the cache to one that does not exist on the build server: `mv ~/.fhir/packages/hl7.fhir.us.core\#current ~/.fhir/packages/hl7.fhir.us.fake\#current`
* Use FPL to install the fake package: `fpl install hl7.fhir.us.fake#current`
  * Note that it logs an ERROR
* From this PR's branch, run the following command to install the fake package: `ts-node src/app.ts install hl7.fhir.us.fake#current`
  * Note that it logs a WARN

**Related Issue:** Fixes #55 
