### PR TITLE
Include an auth header if FPL_REGISTRY_TOKEN is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The [default PackageLoader](src/loader/DefaultPackageLoader.ts) implementation p
 * the standard FHIR cache is used for local storage of unzipped packages (`$USER_HOME/.fhir/packages`)
 * the standard FHIR registry is used (`packages.fhir.org`) for downloading published packages, falling back to `packages2.fhir.org` when necessary
   * unless an `FPL_REGISTRY` environment variable is defined, in which case its value is used as the URL for an NPM registry to use _instead_ of the standard FHIR registry
+    * if an additional `FPL_TOKEN` environment variable is defined, it will be used as an authorization header (bearer token)
 * the `build.fhir.org` build server is used for downloading _current_ builds of packages
 * a 200-item LRU in-memory cache is used to minimize repeated disk reads for resource files
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The [default PackageLoader](src/loader/DefaultPackageLoader.ts) implementation p
 * the standard FHIR cache is used for local storage of unzipped packages (`$USER_HOME/.fhir/packages`)
 * the standard FHIR registry is used (`packages.fhir.org`) for downloading published packages, falling back to `packages2.fhir.org` when necessary
   * unless an `FPL_REGISTRY` environment variable is defined, in which case its value is used as the URL for an NPM registry to use _instead_ of the standard FHIR registry
-    * if an additional `FPL_TOKEN` environment variable is defined, it will be used as an authorization header (bearer token)
+    * if an additional `FPL_REGISTRY_TOKEN` environment variable is defined, it will be used as an authorization header (bearer token)
 * the `build.fhir.org` build server is used for downloading _current_ builds of packages
 * a 200-item LRU in-memory cache is used to minimize repeated disk reads for resource files
 

--- a/src/registry/NPMRegistryClient.ts
+++ b/src/registry/NPMRegistryClient.ts
@@ -47,6 +47,9 @@ export class NPMRegistryClient implements RegistryClient {
     if (tarballRes?.status === 200 && tarballRes?.data) {
       return tarballRes.data;
     }
+    if (tarballRes?.status === 401) {
+      this.log('error', 'Unauthorized! Please check your FPL_REGISTRY_TOKEN.');
+    }
     throw new Error(`Failed to download ${name}#${version} from ${url}`);
   }
 }

--- a/src/registry/NPMRegistryClient.ts
+++ b/src/registry/NPMRegistryClient.ts
@@ -14,9 +14,9 @@ export class NPMRegistryClient implements RegistryClient {
     this.endpoint = endpoint.replace(/\/$/, '');
     this.log = options.log ?? (() => {});
 
-    // If an FPL_TOKEN is provided, set it in the headers for authentication
-    if (process.env.FPL_TOKEN) {
-      this.headers.set('Authorization', `Bearer ${process.env.FPL_TOKEN}`);
+    // If an FPL_REGISTRY_TOKEN is provided, set it in the headers for authentication
+    if (process.env.FPL_REGISTRY_TOKEN) {
+      this.headers.set('Authorization', `Bearer ${process.env.FPL_REGISTRY_TOKEN}`);
     }
   }
 

--- a/src/registry/NPMRegistryClient.ts
+++ b/src/registry/NPMRegistryClient.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'stream';
+import { AxiosHeaders } from 'axios';
 import { axiosGet, LogFunction } from '../utils';
 import { RegistryClient, RegistryClientOptions } from './RegistryClient';
 import { resolveVersion } from './utils';
@@ -6,11 +7,17 @@ import { resolveVersion } from './utils';
 export class NPMRegistryClient implements RegistryClient {
   public endpoint: string;
   private log: LogFunction;
+  private headers: AxiosHeaders = new AxiosHeaders();
 
   constructor(endpoint: string, options?: RegistryClientOptions) {
     // Remove trailing '/' from endpoint if applicable
     this.endpoint = endpoint.replace(/\/$/, '');
     this.log = options.log ?? (() => {});
+
+    // If an FPL_TOKEN is provided, set it in the headers for authentication
+    if (process.env.FPL_TOKEN) {
+      this.headers.set('Authorization', `Bearer ${process.env.FPL_TOKEN}`);
+    }
   }
 
   async resolveVersion(name: string, version: string): Promise<string> {
@@ -24,7 +31,7 @@ export class NPMRegistryClient implements RegistryClient {
     // Get the manifest information about the package from the registry
     let url;
     try {
-      const manifestRes = await axiosGet(`${this.endpoint}/${name}`);
+      const manifestRes = await axiosGet(`${this.endpoint}/${name}`, { headers: this.headers });
       // Find the NPM tarball location in the manifest
       url = manifestRes.data?.versions?.[version]?.dist?.tarball;
     } catch {
@@ -36,7 +43,7 @@ export class NPMRegistryClient implements RegistryClient {
       url = `${this.endpoint}/${name}/-/${name}-${version}.tgz`;
     }
     this.log('info', `Attempting to download ${name}#${version} from ${url}`);
-    const tarballRes = await axiosGet(url, { responseType: 'stream' });
+    const tarballRes = await axiosGet(url, { responseType: 'stream', headers: this.headers });
     if (tarballRes?.status === 200 && tarballRes?.data) {
       return tarballRes.data;
     }

--- a/src/utils/axiosUtils.ts
+++ b/src/utils/axiosUtils.ts
@@ -20,9 +20,17 @@ export async function axiosGet(
     axiosOptions.httpsAgent = new (HttpsProxyAgent as any)(httpsProxy);
     axiosOptions.proxy = false;
   }
-  if (Object.keys(axiosOptions).length > 0) {
-    return await axios.get(url, axiosOptions);
-  } else {
-    return await axios.get(url);
+  try {
+    if (Object.keys(axiosOptions).length > 0) {
+      return await axios.get(url, axiosOptions);
+    } else {
+      return await axios.get(url);
+    }
+  } catch (error) {
+    if (error.response?.status === 401) {
+      return error.response;
+    } else {
+      throw error;
+    }
   }
 }

--- a/test/registry/NPMRegistryClient.test.ts
+++ b/test/registry/NPMRegistryClient.test.ts
@@ -174,6 +174,7 @@ describe('NPMRegistryClient', () => {
     });
 
     afterAll(() => {
+      process.env = OLD_ENV; // restore old env
       authSpy.mockRestore();
     });
 

--- a/test/registry/NPMRegistryClient.test.ts
+++ b/test/registry/NPMRegistryClient.test.ts
@@ -157,7 +157,7 @@ describe('NPMRegistryClient', () => {
 
     beforeAll(() => {
       // inject token into the env
-      process.env = { ...OLD_ENV, FPL_TOKEN: 'test-token' };
+      process.env = { ...OLD_ENV, FPL_REGISTRY_TOKEN: 'test-token' };
 
       authSpy = jest.spyOn(axios, 'get').mockImplementation((uri: string, config: any): any => {
         // verify the Authorization header was set correctly
@@ -178,7 +178,7 @@ describe('NPMRegistryClient', () => {
       authSpy.mockRestore();
     });
 
-    it('should include FPL_TOKEN auth header when token is provided', async () => {
+    it('should include FPL_REGISTRY_TOKEN auth header when token is provided', async () => {
       const client = new NPMRegistryClient('https://my.npm.server.org', { log: loggerSpy.log });
 
       const stream = await client.download('hl7.terminology.r4', '1.2.3-test');

--- a/test/registry/NPMRegistryClient.test.ts
+++ b/test/registry/NPMRegistryClient.test.ts
@@ -151,6 +151,40 @@ describe('NPMRegistryClient', () => {
     });
   });
 
+  describe('#authentication', () => {
+    let authSpy: jest.SpyInstance;
+    const OLD_ENV = process.env;
+
+    beforeAll(() => {
+      // inject token into the env
+      process.env = { ...OLD_ENV, FPL_TOKEN: 'test-token' };
+
+      authSpy = jest.spyOn(axios, 'get').mockImplementation((uri: string, config: any): any => {
+        // verify the Authorization header was set correctly
+        expect(config?.headers?.Authorization).toBe('Bearer test-token');
+
+        // stub package manifest fetch
+        if (uri === 'https://my.npm.server.org/hl7.terminology.r4') {
+          return { data: TERM_PKG_RESPONSE };
+        }
+
+        // stub actual download
+        return { status: 200, data: Readable.from(['auth-test-data']) };
+      });
+    });
+
+    afterAll(() => {
+      authSpy.mockRestore();
+    });
+
+    it('should include FPL_TOKEN auth header when token is provided', async () => {
+      const client = new NPMRegistryClient('https://my.npm.server.org', { log: loggerSpy.log });
+
+      const stream = await client.download('hl7.terminology.r4', '1.2.3-test');
+      expect(stream.read()).toBe('auth-test-data');
+    });
+  });
+
   describe('#download', () => {
     describe('#downloadInvalidVersion', () => {
       beforeEach(() => {


### PR DESCRIPTION
**Description:**
Supports an optional `FPL_REGISTRY_TOKEN` ENV to set an authentication header where a package registry needs to  include auth credentials
