### PR TITLE
Refactor to add token in axiosGet

### DIFF
--- a/src/registry/NPMRegistryClient.ts
+++ b/src/registry/NPMRegistryClient.ts
@@ -1,5 +1,4 @@
 import { Readable } from 'stream';
-import { AxiosHeaders } from 'axios';
 import { axiosGet, LogFunction } from '../utils';
 import { RegistryClient, RegistryClientOptions } from './RegistryClient';
 import { resolveVersion } from './utils';
@@ -7,17 +6,11 @@ import { resolveVersion } from './utils';
 export class NPMRegistryClient implements RegistryClient {
   public endpoint: string;
   private log: LogFunction;
-  private headers: AxiosHeaders = new AxiosHeaders();
 
   constructor(endpoint: string, options?: RegistryClientOptions) {
     // Remove trailing '/' from endpoint if applicable
     this.endpoint = endpoint.replace(/\/$/, '');
     this.log = options.log ?? (() => {});
-
-    // If an FPL_REGISTRY_TOKEN is provided, set it in the headers for authentication
-    if (process.env.FPL_REGISTRY_TOKEN) {
-      this.headers.set('Authorization', `Bearer ${process.env.FPL_REGISTRY_TOKEN}`);
-    }
   }
 
   async resolveVersion(name: string, version: string): Promise<string> {
@@ -31,7 +24,7 @@ export class NPMRegistryClient implements RegistryClient {
     // Get the manifest information about the package from the registry
     let url;
     try {
-      const manifestRes = await axiosGet(`${this.endpoint}/${name}`, { headers: this.headers });
+      const manifestRes = await axiosGet(`${this.endpoint}/${name}`);
       // Find the NPM tarball location in the manifest
       url = manifestRes.data?.versions?.[version]?.dist?.tarball;
     } catch {
@@ -43,7 +36,7 @@ export class NPMRegistryClient implements RegistryClient {
       url = `${this.endpoint}/${name}/-/${name}-${version}.tgz`;
     }
     this.log('info', `Attempting to download ${name}#${version} from ${url}`);
-    const tarballRes = await axiosGet(url, { responseType: 'stream', headers: this.headers });
+    const tarballRes = await axiosGet(url, { responseType: 'stream' });
     if (tarballRes?.status === 200 && tarballRes?.data) {
       return tarballRes.data;
     }

--- a/src/utils/axiosUtils.ts
+++ b/src/utils/axiosUtils.ts
@@ -20,6 +20,15 @@ export async function axiosGet(
     axiosOptions.httpsAgent = new (HttpsProxyAgent as any)(httpsProxy);
     axiosOptions.proxy = false;
   }
+  
+  // If we are using a custom FPL registry and have a token, set the Authorization header
+  if (process.env.FPL_REGISTRY && process.env.FPL_REGISTRY_TOKEN) {
+    axiosOptions.headers = {
+      ...axiosOptions.headers,
+      Authorization: `Bearer ${process.env.FPL_REGISTRY_TOKEN}`
+    };
+  }
+
   try {
     if (Object.keys(axiosOptions).length > 0) {
       return await axios.get(url, axiosOptions);

--- a/src/utils/axiosUtils.ts
+++ b/src/utils/axiosUtils.ts
@@ -22,7 +22,11 @@ export async function axiosGet(
   }
 
   // If we are using a custom FPL registry and have a token, set the Authorization header
-  if (process.env.FPL_REGISTRY && process.env.FPL_REGISTRY_TOKEN) {
+  if (
+    process.env.FPL_REGISTRY &&
+    process.env.FPL_REGISTRY_TOKEN &&
+    url.startsWith(process.env.FPL_REGISTRY)
+  ) {
     axiosOptions.headers = {
       ...axiosOptions.headers,
       Authorization: `Bearer ${process.env.FPL_REGISTRY_TOKEN}`

--- a/src/utils/axiosUtils.ts
+++ b/src/utils/axiosUtils.ts
@@ -20,7 +20,7 @@ export async function axiosGet(
     axiosOptions.httpsAgent = new (HttpsProxyAgent as any)(httpsProxy);
     axiosOptions.proxy = false;
   }
-  
+
   // If we are using a custom FPL registry and have a token, set the Authorization header
   if (process.env.FPL_REGISTRY && process.env.FPL_REGISTRY_TOKEN) {
     axiosOptions.headers = {

--- a/test/registry/NPMRegistryClient.test.ts
+++ b/test/registry/NPMRegistryClient.test.ts
@@ -157,7 +157,11 @@ describe('NPMRegistryClient', () => {
 
     beforeAll(() => {
       // inject token into the env
-      process.env = { ...OLD_ENV, FPL_REGISTRY_TOKEN: 'test-token' };
+      process.env = {
+        ...OLD_ENV,
+        FPL_REGISTRY: 'https://registry.example.org/packages',
+        FPL_REGISTRY_TOKEN: 'test-token'
+      };
 
       authSpy = jest.spyOn(axios, 'get').mockImplementation((uri: string, config: any): any => {
         // verify the Authorization header was set correctly


### PR DESCRIPTION
Downloading the manifest (when attempting to install #latest, e.g. lookupLatestVersion) was failing because of missing token.

This PR removes the FPL_REGISTRY_TOKEN handling from the NPMRegistryClient  and adds to axiosGet utility. We found that before this, when dowloading "#latest", the `lookUpLatestVersion` was failing because it was missing the auth token. This refactor puts the logic to add the header in a more central place.
